### PR TITLE
fixed flag GOOS, it always be linux and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is early development version. I am currently considering:
 ## Roadmap:
 
 - [ ] On a Linux system, changing symbolic link, by default changes only the target of the symbolic link. I'd like to change ownership of symbolic link itself
-- [ ] man pages
+- [x] man pages
 - [ ] DEB package
 - [ ] RPM package
 - [ ] MacOS PKG
@@ -26,7 +26,7 @@ If you want to build `chref` from source, please verify to have already installe
 Then run this command:
 
 ```bash
-go build -v -ldflags="-X 'chref/build.Version=$(cat VERSION)' -X 'chref/build.BuildUser=$(id -u -n)' -X 'chref/build.BuildTime=$(date)'"
+go build -v -ldflags="-X 'github.com/Sfrisio/chref/build.Version=$(cat VERSION)' -X 'github.com/Sfrisio/chref/build.BuildUser=Team chref' -X 'github.com/Sfrisio/chref/build.BuildTime=$(date)'"
 ```
 
 If you want to build automatically `chref` for all the supported platform consider to use `binary-builder.sh` provided in *scripts* folder.

--- a/scripts/binary-builder.sh
+++ b/scripts/binary-builder.sh
@@ -12,10 +12,10 @@ allSupportedOS=("linux" "freebsd" "darwin")
 echo -e "\n${BRED}**** chref binary building ****${NC}\n"
 
 for os in ${allSupportedOS[@]}; do 
-    env GOOS=linux GOARCH=amd64 go build -o pkg/${PKG_NAME}${os}_amd64/bin/chref -v -ldflags="-X 'github.com/Sfrisio/chref/build.Version=$(cat VERSION)' -X 'github.com/Sfrisio/chref/build.BuildUser=Team chref' -X 'github.com/Sfrisio/chref/build.BuildTime=$(date)'" && cp -p {VERSION,LICENSE} pkg/${PKG_NAME}${os}_amd64/.
+    env GOOS=${os} GOARCH=amd64 go build -o pkg/${PKG_NAME}${os}_amd64/bin/chref -v -ldflags="-X 'github.com/Sfrisio/chref/build.Version=$(cat VERSION)' -X 'github.com/Sfrisio/chref/build.BuildUser=Team chref' -X 'github.com/Sfrisio/chref/build.BuildTime=$(date)'" && cp -p {VERSION,LICENSE} pkg/${PKG_NAME}${os}_amd64/.
     if [[ ${os} != "freebsd" ]]; then
         echo -e "${GREEN}[+] building ${os} arm64 ...${NC}"
-        env GOOS=linux GOARCH=arm64 go build -o pkg/${PKG_NAME}${os}_arm64/bin/chref -v -ldflags="-X 'github.com/Sfrisio/chref/build.Version=$(cat VERSION)' -X 'github.com/Sfrisio/chref/build.BuildUser=Team chref' -X 'github.com/Sfrisio/chref/build.BuildTime=$(date)'" && cp -p {VERSION,LICENSE} pkg/${PKG_NAME}${os}_arm64/.
+        env GOOS=${os} GOARCH=arm64 go build -o pkg/${PKG_NAME}${os}_arm64/bin/chref -v -ldflags="-X 'github.com/Sfrisio/chref/build.Version=$(cat VERSION)' -X 'github.com/Sfrisio/chref/build.BuildUser=Team chref' -X 'github.com/Sfrisio/chref/build.BuildTime=$(date)'" && cp -p {VERSION,LICENSE} pkg/${PKG_NAME}${os}_arm64/.
     fi
 done
 


### PR DESCRIPTION
Fixed an issue that prevented binaries from being generated correctly.
GOOS was not dynamic, but was always enhanced with `linux`